### PR TITLE
resolves #11 by replacing instances of git@github.com links with https links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pixi run tpl-init-cruft
 
 # alternatively:
 pip install cruft jinja2-ospath
-cruft create git@github.com:l-mds/local-data-stack.git
+cruft create https://github.com/l-mds/local-data-stack.git
 
 cd <<your project name>>
 git init

--- a/doc/README.md
+++ b/doc/README.md
@@ -31,7 +31,7 @@ To validate dependencies (from the branch/PR) execute:
 
 ```bash
 # create from the branch
-cruft create --checkout <<new-branch>> git@github.com:l-mds/local-data-stack.git
+cruft create --checkout <<new-branch>> https://github.com/l-mds/local-data-stack.git
 
 
 # update from the branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,6 @@ description = "Format yaml & toml files"
 env = { RUST_LOG = "warn" }
 
 [tool.pixi.tasks.tpl-init-cruft]
-cmd = "pixi run -e template cruft create git@github.com:l-mds/local-data-stack.git"
+cmd = "pixi run -e template cruft create https://github.com/l-mds/local-data-stack.git"
 description = "Initialize template with cruft"
 


### PR DESCRIPTION
There are three instances where cruft and pixi call **git@github.com:l-mds/local-data-stack.git** which is only successful when a user has ssh keys configured on their workstation. Replacing these links with **https://github.com/l-mds/local-data-stack.git** removes this requirement and lowers the barrier for installation.